### PR TITLE
Add CI checks for catalog-template.yaml and bundle image validation

### DIFF
--- a/.github/workflows/validate-catalogs.yaml
+++ b/.github/workflows/validate-catalogs.yaml
@@ -1,0 +1,22 @@
+name: Validate catalogs
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+      - dev
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install opm
+        run: make opm
+
+      - name: Validate catalogs
+        run: make validate-catalog

--- a/.tekton/volsync-fbc-validate-bundle-images-dev-pull-request.yaml
+++ b/.tekton/volsync-fbc-validate-bundle-images-dev-pull-request.yaml
@@ -8,11 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "dev" &&
-      (".tekton/volsync-fbc-validate-bundle-images-dev-pull-request.yaml".pathChanged() ||
-      "catalog-template.yaml".pathChanged() ||
-      "build/validate-bundle-images.sh".pathChanged() ||
-      ".tekton/images-mirror-set.yaml".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "dev"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: volsync-fbc-dev

--- a/.tekton/volsync-fbc-validate-bundle-images-dev-pull-request.yaml
+++ b/.tekton/volsync-fbc-validate-bundle-images-dev-pull-request.yaml
@@ -1,0 +1,100 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/volsync-operator-product-fbc?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "dev" &&
+      (".tekton/volsync-fbc-validate-bundle-images-dev-pull-request.yaml".pathChanged() ||
+      "catalog-template.yaml".pathChanged() ||
+      "build/validate-bundle-images.sh".pathChanged() ||
+      ".tekton/images-mirror-set.yaml".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: volsync-fbc-dev
+    pipelines.appstudio.openshift.io/type: test
+  name: volsync-fbc-validate-bundle-images-dev-on-pull-request
+  namespace: volsync-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+  pipelineSpec:
+    params:
+      - name: git-url
+        type: string
+      - name: revision
+        type: string
+    workspaces:
+      - name: source
+      - name: git-auth
+    tasks:
+      - name: validate-bundle-images
+        params:
+          - name: git-url
+            value: $(params.git-url)
+          - name: revision
+            value: $(params.revision)
+        workspaces:
+          - name: source
+            workspace: source
+          - name: git-auth
+            workspace: git-auth
+        taskSpec:
+          params:
+            - name: git-url
+              type: string
+            - name: revision
+              type: string
+          workspaces:
+            - name: source
+            - name: git-auth
+          volumes:
+            - name: registry-auth
+              secret:
+                secretName: volsync-redhat-registries-pull-secret
+                items:
+                  - key: .dockerconfigjson
+                    path: auth.json
+          steps:
+            - name: validate
+              image: quay.io/konflux-ci/konflux-test:latest
+              workingDir: $(workspaces.source.path)
+              env:
+                - name: PARAM_URL
+                  value: $(params.git-url)
+                - name: PARAM_REVISION
+                  value: $(params.revision)
+                - name: REGISTRY_AUTH_FILE
+                  value: /etc/containers/auth/auth.json
+              volumeMounts:
+                - name: registry-auth
+                  mountPath: /etc/containers/auth
+                  readOnly: true
+              script: |
+                #!/bin/bash
+                set -eo pipefail
+
+                export HOME=/tmp
+                git config --global --add safe.directory /workspace/source
+
+                echo "=== Cloning repository ==="
+                git clone --depth=1 "${PARAM_URL}" .
+                git fetch --depth=1 origin "${PARAM_REVISION}"
+                git checkout "${PARAM_REVISION}"
+
+                echo ""
+                bash build/validate-bundle-images.sh
+  workspaces:
+    - name: source
+      emptyDir: {}
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/volsync-fbc-validate-bundle-images-pull-request.yaml
+++ b/.tekton/volsync-fbc-validate-bundle-images-pull-request.yaml
@@ -8,11 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
-      (".tekton/volsync-fbc-validate-bundle-images-pull-request.yaml".pathChanged() ||
-      "catalog-template.yaml".pathChanged() ||
-      "build/validate-bundle-images.sh".pathChanged() ||
-      ".tekton/images-mirror-set.yaml".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: volsync-fbc

--- a/.tekton/volsync-fbc-validate-bundle-images-pull-request.yaml
+++ b/.tekton/volsync-fbc-validate-bundle-images-pull-request.yaml
@@ -1,0 +1,100 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/volsync-operator-product-fbc?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/volsync-fbc-validate-bundle-images-pull-request.yaml".pathChanged() ||
+      "catalog-template.yaml".pathChanged() ||
+      "build/validate-bundle-images.sh".pathChanged() ||
+      ".tekton/images-mirror-set.yaml".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: volsync-fbc
+    pipelines.appstudio.openshift.io/type: test
+  name: volsync-fbc-validate-bundle-images-on-pull-request
+  namespace: volsync-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+  pipelineSpec:
+    params:
+      - name: git-url
+        type: string
+      - name: revision
+        type: string
+    workspaces:
+      - name: source
+      - name: git-auth
+    tasks:
+      - name: validate-bundle-images
+        params:
+          - name: git-url
+            value: $(params.git-url)
+          - name: revision
+            value: $(params.revision)
+        workspaces:
+          - name: source
+            workspace: source
+          - name: git-auth
+            workspace: git-auth
+        taskSpec:
+          params:
+            - name: git-url
+              type: string
+            - name: revision
+              type: string
+          workspaces:
+            - name: source
+            - name: git-auth
+          volumes:
+            - name: registry-auth
+              secret:
+                secretName: volsync-redhat-registries-pull-secret
+                items:
+                  - key: .dockerconfigjson
+                    path: auth.json
+          steps:
+            - name: validate
+              image: quay.io/konflux-ci/konflux-test:latest
+              workingDir: $(workspaces.source.path)
+              env:
+                - name: PARAM_URL
+                  value: $(params.git-url)
+                - name: PARAM_REVISION
+                  value: $(params.revision)
+                - name: REGISTRY_AUTH_FILE
+                  value: /etc/containers/auth/auth.json
+              volumeMounts:
+                - name: registry-auth
+                  mountPath: /etc/containers/auth
+                  readOnly: true
+              script: |
+                #!/bin/bash
+                set -eo pipefail
+
+                export HOME=/tmp
+                git config --global --add safe.directory /workspace/source
+
+                echo "=== Cloning repository ==="
+                git clone --depth=1 "${PARAM_URL}" .
+                git fetch --depth=1 origin "${PARAM_REVISION}"
+                git checkout "${PARAM_REVISION}"
+
+                echo ""
+                bash build/validate-bundle-images.sh
+  workspaces:
+    - name: source
+      emptyDir: {}
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+status: {}

--- a/build/validate-bundle-images.sh
+++ b/build/validate-bundle-images.sh
@@ -1,0 +1,112 @@
+#! /bin/bash
+# Validates catalog-template.yaml:
+#
+#   1. TEMPLATE RENDERING — opm renders the template without error, catching
+#      broken YAML, missing fields, invalid upgrade graphs, and unreachable images.
+#
+#   2. IMAGE EXISTENCE — every olm.bundle image is reachable via skopeo inspect.
+#      If an image is not found at its primary URL, falls back to quay.io mirrors
+#      defined in .tekton/images-mirror-set.yaml using longest-prefix matching.
+#      Images found only on a mirror are treated as a warning (unreleased).
+#
+# Mirror fallback follows the same approach as the Konflux community task:
+# https://github.com/konflux-ci/community-catalog/tree/main/tasks/validate-fbc-images-resolvable
+#
+# Requires registry credentials via REGISTRY_AUTH_FILE env var or skopeo login.
+#
+# Requires: bash, yq, opm, skopeo
+
+set -eo pipefail
+
+MIRROR_SET=".tekton/images-mirror-set.yaml"
+
+if [[ ! -f "catalog-template.yaml" ]]; then
+  echo "error: catalog-template.yaml not found. Script must be run from the base of the repository."
+  exit 1
+fi
+
+# Load mirror sources from the ImageDigestMirrorSet
+mirror_sources=()
+if [[ -f "${MIRROR_SET}" ]]; then
+  mapfile -t mirror_sources < <(yq '.spec.imageDigestMirrors[].source' "${MIRROR_SET}")
+  echo "=== Loaded ${#mirror_sources[@]} mirror source(s) from ${MIRROR_SET} ==="
+else
+  echo "=== WARNING: ${MIRROR_SET} not found — mirror fallback disabled ==="
+fi
+
+echo ""
+echo "=== Step 1: Rendering catalog-template.yaml (opm) ==="
+if ! opm alpha render-template basic catalog-template.yaml -o yaml > /dev/null; then
+  echo ""
+  echo "ERROR: catalog-template.yaml failed to render."
+  echo "Check the template for malformed entries, missing fields, or unreachable images."
+  exit 1
+fi
+echo "  Template rendered successfully."
+
+echo ""
+echo "=== Step 2: Checking bundle images in catalog-template.yaml ==="
+failed=0
+warned=0
+while IFS=' ' read -r bundle_name bundle_image; do
+  echo "  Checking ${bundle_name} ..."
+
+  if timeout 60 skopeo inspect --override-os=linux --override-arch=amd64 "docker://${bundle_image}" > /dev/null 2>&1; then
+    echo "  -> OK: available at primary URL"
+    continue
+  fi
+
+  echo "  -> Not found at primary URL, checking mirrors ..."
+  image_repo="${bundle_image%%@*}"
+  image_digest="${bundle_image##*@}"
+
+  # Longest-prefix matching to find the right IDMS entry, then try all its mirrors
+  best_match_source=""
+  best_match_index=""
+  for i in "${!mirror_sources[@]}"; do
+    source="${mirror_sources[$i]}"
+    if [[ "${image_repo}" == "${source}"* && ${#source} -gt ${#best_match_source} ]]; then
+      best_match_source="${source}"
+      best_match_index="${i}"
+    fi
+  done
+
+  if [[ -z "${best_match_source}" ]]; then
+    echo "  -> ERROR: no mirror configured for ${image_repo}"
+    failed=1
+    continue
+  fi
+
+  image_suffix="${image_repo#"${best_match_source}"}"
+  found_on_mirror=false
+  while IFS= read -r mirror; do
+    resolved_url="${mirror}${image_suffix}@${image_digest}"
+    echo "  -> Trying mirror: ${resolved_url}"
+    if timeout 60 skopeo inspect --override-os=linux --override-arch=amd64 "docker://${resolved_url}" > /dev/null 2>&1; then
+      found_on_mirror=true
+      break
+    fi
+  done < <(yq ".spec.imageDigestMirrors[${best_match_index}].mirrors[]" "${MIRROR_SET}")
+
+  if [[ "${found_on_mirror}" == true ]]; then
+    echo "  -> WARNING: found on mirror but not at primary URL (unreleased)"
+    warned=$((warned + 1))
+  else
+    echo "  -> ERROR: not found at primary URL or any mirror: ${bundle_image}"
+    failed=1
+  fi
+done < <(yq '.entries[] | select(.schema == "olm.bundle") | .name + " " + .image' catalog-template.yaml)
+
+if [[ ${warned} -gt 0 ]]; then
+  echo ""
+  echo "NOTE: ${warned} image(s) found on mirror only — expected for unreleased bundles."
+fi
+
+if [[ ${failed} -ne 0 ]]; then
+  echo ""
+  echo "ERROR: One or more bundle images are missing or inaccessible."
+  exit 1
+fi
+
+echo ""
+echo "=== All bundle images verified ==="


### PR DESCRIPTION
- **GH Action**: runs `opm validate` on committed catalog directories (PRs to main/dev)
- **Tekton pipelines**: render `catalog-template.yaml` with `opm` and verify all `olm.bundle` images are reachable via `skopeo inspect` (PRs to main/dev)
- **IDMS mirror fallback**: if an image is not found on `registry.redhat.io`, falls back to `quay.io` mirrors defined in `.tekton/images-mirror-set.yaml` using longest-prefix matching — images found only on a mirror are treated as warnings (unreleased bundles)
- **Standalone script** (`build/validate-bundle-images.sh`) for local use and Tekton execution