### PR TITLE
Add snapshot script docs and pre-flight cluster check

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,24 @@ index for the `volsync-product` operator package:
    the image's release. In this case, you need to revert the bundle reference to the Konflux one for
    the script to complete.
 
+## Generating a Konflux Snapshot
+
+Use the [`gen-fbc-snapshot.sh`](gen-fbc-snapshot.sh) script to generate a Konflux Snapshot
+containing only the FBC components supported for a specific VolSync version. The script looks up
+[`supported-versions.json`](supported-versions.json) at the given commit to determine which OCP
+versions apply, then queries each component's `lastPromotedImage` from the Konflux cluster to
+build the snapshot YAML.
+
+**Prerequisites:** `gh`, `oc`, `jq`. `KUBECONFIG` must point to the Konflux cluster.
+
+```bash
+# Production snapshot
+./gen-fbc-snapshot.sh <commit_sha> <volsync_version> prod
+
+# Dev snapshot
+./gen-fbc-snapshot.sh <commit_sha> <volsync_version> dev
+```
+
 ## Testing an FBC image
 
 A catalog source can be created pointing to the FBC image as follows:

--- a/gen-fbc-snapshot.sh
+++ b/gen-fbc-snapshot.sh
@@ -18,6 +18,12 @@ set -euo pipefail
 REPO="stolostron/volsync-operator-product-fbc"
 NS="volsync-tenant"
 
+if ! oc -n "$NS" get components --no-headers -o name &>/dev/null; then
+  echo "ERROR: cannot access components in namespace '${NS}'." >&2
+  echo "Check that you are logged in (oc login) and KUBECONFIG points to the Konflux cluster." >&2
+  exit 1
+fi
+
 # --- args ---
 COMMIT="${1:?Usage: $0 <commit_sha> <volsync_version> <prod|dev> [no]}"
 VS_VER_FULL="${2:?Usage: $0 <commit_sha> <volsync_version> <prod|dev> [no]}"


### PR DESCRIPTION
## Summary
- Add README section documenting `gen-fbc-snapshot.sh` usage (prerequisites, examples)
- Add pre-flight check to the script that fails fast with a clear error when not logged into the Konflux cluster, instead of silently reporting all components as "not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)