### PR TITLE
fix: harden validate-catalogs workflow against token exfiltration

### DIFF
--- a/.github/workflows/validate-catalogs.yaml
+++ b/.github/workflows/validate-catalogs.yaml
@@ -18,6 +18,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Install opm
         run: make opm

--- a/.github/workflows/validate-catalogs.yaml
+++ b/.github/workflows/validate-catalogs.yaml
@@ -7,6 +7,9 @@ on:
       - main
       - dev
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -14,6 +17,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Install opm
         run: make opm


### PR DESCRIPTION
Add explicit `permissions: contents: read` to scope the GITHUB_TOKEN to read-only and `persist-credentials: false` to the checkout step.

The workflow only clones the repo and runs `opm validate` — neither step needs write access or git credentials.